### PR TITLE
feat(project): add compressed SVG preview on project update

### DIFF
--- a/src/app/SearchParamsManager.tsx
+++ b/src/app/SearchParamsManager.tsx
@@ -6,6 +6,7 @@ import { AxiosError } from 'axios';
 
 import { apiClient } from 'src/shared/api/apiClient';
 import { compress, decompress } from 'src/shared/functions/compress';
+import { generatePreview } from 'src/shared/functions/generatePreview';
 import {
   NotesArrayState,
   setNotes
@@ -70,10 +71,13 @@ const SearchParamsManager = () => {
   const projectUserId = useSelector((state: RootState) => state.projectUserId.userId);
   const isDragging = useSelector((state: RootState) => state.user.isDragging);
   
-  async function updateLink(link: string) {
-    await apiClient.put(`/projects/${id}`, {
-      link
-    });
+  async function updateProject({ link, image }: { link: string; image?: string }) {
+    const payload: Record<string, string> = { link };
+    if (image) {
+      payload.image = image;
+    }
+    
+    await apiClient.put(`/projects/${id}`, payload);
   }
 
   useEffect(() => {
@@ -149,6 +153,14 @@ const SearchParamsManager = () => {
 
     const obj = { notesArray: storedNotesArray, settings, soundSettings };
     const compressed = compress(obj);
+    
+    let compressedImage: string | undefined;
+    try {
+      const previewSvg = generatePreview(notesArray);
+      compressedImage = compress(previewSvg);
+    } catch (err) {
+      console.warn('Preview generation failed, sending without image', err);
+    }
 
     if (id) {
       try {
@@ -157,7 +169,7 @@ const SearchParamsManager = () => {
           return;
         }
 
-        updateLink(compressed);
+        updateProject({ link: compressed, image: compressedImage });
       } catch (e: unknown) {
         const error = e as AxiosError;
         if (error.response?.status === 403) {
@@ -165,7 +177,7 @@ const SearchParamsManager = () => {
           return;
         }
 
-        console.error('Error for updating link');
+        console.error('Error for updating project');
       }
     } else {
       setSearchParams('params=' + compressed);

--- a/src/pages/InstrumentPage/InstrumentPage.tsx
+++ b/src/pages/InstrumentPage/InstrumentPage.tsx
@@ -29,8 +29,7 @@ const InstrumentPage = ({ className = '' }: InstrumentPageProps) => {
   const notesArray = useSelector(
     (state: RootState) => state.notesArray.notesArray
   );
-
-  console.log(generatePreview(notesArray));
+  
 
   return (
     <main

--- a/src/shared/lib/msw/handlers/project.ts
+++ b/src/shared/lib/msw/handlers/project.ts
@@ -92,10 +92,23 @@ export const projectHandler = [
       );
     }
 
-    const { name = '', link = '' , autosave = ''} =
-      (await request.json()) as UpdateRequestBody;
-    return HttpResponse.json({
-      status: 200
-    });
+    const body = await request.json() as UpdateRequestBody;
+
+    projects[id] = {
+      ...projects[id],
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.link !== undefined && { link: body.link }),
+      ...(body.autosave !== undefined && { autosave: body.autosave }),
+      ...(body.image !== undefined && { image: body.image })
+    };
+
+    return HttpResponse.json(
+      { 
+        status: 200,
+        message: 'Project updated',
+        data: projects[id]
+      },
+      { status: 200 }
+    );
   })
 ];

--- a/src/shared/lib/msw/handlers/project.ts
+++ b/src/shared/lib/msw/handlers/project.ts
@@ -95,11 +95,10 @@ export const projectHandler = [
     const body = await request.json() as UpdateRequestBody;
 
     projects[id] = {
-      ...projects[id],
-      ...(body.name !== undefined && { name: body.name }),
-      ...(body.link !== undefined && { link: body.link }),
-      ...(body.autosave !== undefined && { autosave: body.autosave }),
-      ...(body.image !== undefined && { image: body.image })
+      ...(!!body.name && { name: body.name }),
+      ...(!!body.link && { link: body.link }),
+      ...(!!body.autosave && { autosave: body.autosave }),
+      ...(!!body.image && { image: body.image })
     };
 
     return HttpResponse.json(

--- a/src/shared/lib/msw/types.ts
+++ b/src/shared/lib/msw/types.ts
@@ -7,6 +7,7 @@ export type UpdateRequestBody = {
   name?: string;
   link?: string;
   autosave?: boolean;
+  image?: string;
 };
 
 export type Project = {
@@ -16,4 +17,5 @@ export type Project = {
   link: string;
   userId: number;
   autosave: boolean;
+  image?: string;
 };


### PR DESCRIPTION
Добавить сохранение превью в проект [#111](https://tree.taiga.io/project/titkov2002-websequencer/task/111)

- Add the `image` field to the UpdateRequestBody and Project types (msw/types.ts)
- Update the MSW handler PUT /projects/:id to save the image in the mock memory
- Integrate generatePreview into SearchParamsManager to generate SVG previews
- Add preview compression via compress() before sending to the backend
- Rename updateLink to updateProject with support for multiple fields